### PR TITLE
[CLOUD-2235] KIE specific concreate modules moved to own repo

### DIFF
--- a/decisioncentral/image.yaml
+++ b/decisioncentral/image.yaml
@@ -262,6 +262,9 @@ modules:
           - git:
                   url: https://github.com/jboss-openshift/cct_module.git
                   ref: master
+          - git:
+                  url: https://github.com/jboss-container-images/jboss-kie-modules.git
+                  ref: master
       install:
           - name: dynamic-resources
           - name: s2i-common

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -330,6 +330,9 @@ modules:
           - git:
                   url: https://github.com/jboss-openshift/cct_module.git
                   ref: master
+          - git:
+                  url: https://github.com/jboss-container-images/jboss-kie-modules.git
+                  ref: master
       install:
           - name: dynamic-resources
           - name: s2i-common


### PR DESCRIPTION
Depends on
https://github.com/jboss-openshift/cct_module/pull/175
https://github.com/jboss-container-images/jboss-kie-modules/pull/1