### PR TITLE
[CLOUD-2235] Add jboss-kie-modules module repository

### DIFF
--- a/decisioncentral/image.yaml
+++ b/decisioncentral/image.yaml
@@ -263,8 +263,11 @@ ports:
 modules:
       repositories:
           - git:
-                  url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+              url: https://github.com/jboss-openshift/cct_module.git
+              ref: master
+          - git:
+              url: https://github.com/jboss-container-images/jboss-kie-modules.git
+              ref: master
       install:
           - name: dynamic-resources
           - name: s2i-common

--- a/decisioncentral/image.yaml
+++ b/decisioncentral/image.yaml
@@ -297,8 +297,8 @@ modules:
           - name: os-eap-extensions
           - name: openshift-layer
           - name: openshift-passwd
-          - name: os-bpmsuite-common
-          - name: os-bpmsuite-businesscentral
+          - name: os.bpmsuite.common
+          - name: os.bpmsuite.businesscentral
           - name: jboss-maven
 packages:
       repositories:

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -331,8 +331,11 @@ ports:
 modules:
       repositories:
           - git:
-                  url: https://github.com/jboss-openshift/cct_module.git
-                  ref: master
+              url: https://github.com/jboss-openshift/cct_module.git
+              ref: master
+          - git:
+              url: https://github.com/jboss-container-images/jboss-kie-modules.git
+              ref: master
       install:
           - name: dynamic-resources
           - name: s2i-common

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -366,8 +366,8 @@ modules:
           - name: os-eap-extensions
           - name: openshift-layer
           - name: openshift-passwd
-          - name: os-bpmsuite-common
-          - name: os-bpmsuite-executionserver
+          - name: os.bpmsuite.common
+          - name: os.bpmsuite.executionserver
           - name: jboss-maven
 packages:
       repositories:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2235

The KIE modules will be moving from cct_modules to
the new repository added in this commit.