### PR TITLE
[RHDM-508] rhdm70-kieserver OpenShift template broken. Unable to import.

### DIFF
--- a/templates/rhdm70-kieserver.yaml
+++ b/templates/rhdm70-kieserver.yaml
@@ -86,6 +86,7 @@ parameters:
   description: KIE server controller protocol. To use Decision Central or a controller to manage this Decision
     Server, set this parameter to the protocol part of the URL for the Decision Central or controller. (Used to 
     set the org.kie.server.controller system property).
+  name: KIE_SERVER_CONTROLLER_PROTOCOL
   value: http
   required: false
   description: KIE server controller service. To use Decision Central that is hosted on the same OpenShift environment


### PR DESCRIPTION
Signed-off-by: David Ward <dward@redhat.com>

[RHDM-508] rhdm70-kieserver OpenShift template broken. Unable to import.
https://issues.jboss.org/browse/RHDM-508