### PR TITLE
[RHDM-536] Decision Central OpenShift container does not expose Git HTTP and SSH ports

### DIFF
--- a/templates/rhdm70-full.yaml
+++ b/templates/rhdm70-full.yaml
@@ -233,6 +233,20 @@ objects:
   apiVersion: v1
   spec:
     ports:
+    - port: 8001
+      targetPort: 8001
+    selector:
+      deploymentConfig: "${APPLICATION_NAME}-rhdmcentr"
+  metadata:
+    name: ${APPLICATION_NAME}-rhdmcentr-git-ssh
+    labels:
+      application: "${APPLICATION_NAME}"
+    annotations:
+      description: The Decision Central Git SSH port
+- kind: Service
+  apiVersion: v1
+  spec:
+    ports:
     - port: 8080
       targetPort: 8080
     selector:


### PR DESCRIPTION
[RHDM-536] Decision Central OpenShift container does not expose Git HTTP and SSH ports
https://issues.jboss.org/browse/RHDM-536

Signed-off-by: David Ward <dward@redhat.com>