### PR TITLE
[CLOUD-2692] move material out to cct_modules

### DIFF
--- a/decisioncentral/image.yaml
+++ b/decisioncentral/image.yaml
@@ -16,10 +16,6 @@ labels:
     - name: "io.openshift.tags"
       value: "javaee,eap,eap7,rhdm,rhdm7"
 envs:
-    - name: "JBOSS_MODULES_SYSTEM_PKGS"
-      value: "org.jboss.logmanager,jdk.nashorn.api"
-    - name: "DEFAULT_ADMIN_USERNAME"
-      value: "eapadmin"
     - name: "HTTPS_ENABLE_HTTP2"
       value: "true"
     - name: "KIE_ADMIN_USER"
@@ -64,75 +60,15 @@ envs:
     - name: "KIE_SERVER_PWD"
       example: "execution1!"
       description: "KIE execution server password for basic authentication (Sets the org.kie.server.pwd system property)"
-    - name: "JAVA_OPTS_APPEND"
-      example: "-Dfoo=bar"
-      description: "Server startup options."
-    - name: "JBOSS_MODULES_SYSTEM_PKGS_APPEND"
-      example: "org.jboss.byteman"
-      description: "Comma-separated list of package names that will be appended to the JBOSS_MODULES_SYSTEM_PKGS environment variable."
-    - name: "MQ_SIMPLE_DEFAULT_PHYSICAL_DESTINATION"
-      example: "false"
-      description: "For backwards compatability, set to true to use 'MyQueue' and 'MyTopic' as physical destination name defaults instead of 'queue/MyQueue' and 'topic/MyTopic'."
-    - name: "DEFAULT_JMS_CONNECTION_FACTORY"
-      example: "java:jboss/DefaultJMSConnectionFactory"
-      description: "Specify the default JNDI binding for the JMS connection factory (jms-connection-factory='java:jboss/DefaultJMSConnectionFactory')."
-    - name: "CLI_GRACEFUL_SHUTDOWN"
-      example: "true"
-      description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."
     - name: "SCRIPT_DEBUG"
       example: "true"
       description: "If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed."
-    - name: "JAVA_MAX_MEM_RATIO"
-      example: "50"
-      description: "This is used to calculate a default maximal heap memory based on a containers restriction. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option is added."
-    - name: "JAVA_INITIAL_MEM_RATIO"
-      example: "100"
-      description: "This is used to calculate a default initial heap memory based the maximum heap memory.  The default is `100` which means 100% of the maximal heap is used for the initial heap size.  You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added."
-    - name: "JAVA_MAX_INITIAL_MEM"
-      example: "4096"
-      description: "The maximum size of the initial heap memory, if the calculated default initial heap is larger then it will be capped at this value.  The default is 4096 MB."
-    - name: "JAVA_CORE_LIMIT"
-      example: "2"
-      description: "Core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt.  Used to configure the number of GC threads and parallelism for ForkJoinPool.  Defaults to container core limit."
-    - name: "JAVA_DIAGNOSTICS"
-      example: "true"
-      description: "Set this to get some diagnostics information to standard output when things are happening. **Disabled by default.**"
-    - name: "GC_MIN_HEAP_FREE_RATIO"
-      example: "20"
-      description: "Minimum percentage of heap free after GC to avoid expansion."
-    - name: "GC_MAX_HEAP_FREE_RATIO"
-      example: "40"
-      description: "Maximum percentage of heap free after GC to avoid shrinking."
-    - name: "GC_TIME_RATIO"
-      example: "4"
-      description: "Specifies the ratio of the time spent outside the garbage collection (for example, the time spent for application execution) to the time spent in the garbage collection."
-    - name: "GC_ADAPTIVE_SIZE_POLICY_WEIGHT"
-      example: "90"
-      description: "The weighting given to the current GC time versus previous GC times."
-    - name: "GC_MAX_METASPACE_SIZE"
-      example: "100"
-      description: "The maximum metaspace size."
     - name: "WORKBENCH_MAX_METASPACE_SIZE"
       example: "512"
       description: "The maximum metaspace for the Decision Central, it will set the GC_MAX_METASPACE_SIZE, its default value is 1024mb."
     - name: "CUSTOM_INSTALL_DIRECTORIES"
       example: "custom,shared"
       description: "A list of comma-separated directories used for installation and configuration of artifacts for the image during the S2I process."
-    - name: "CONTAINER_HEAP_PERCENT"
-      example: "0.5"
-      description: "Deprecated.  See JAVA_MAX_MEM_RATIO."
-    - name: "INITIAL_HEAP_PERCENT"
-      example: "0.5"
-      description: "Deprecated.  See JAVA_INITIAL_MEM_RATIO."
-    - name: "PROBE_DISABLE_BOOT_ERRORS_CHECK"
-      example: "true"
-      description: "Disable the boot errors check in the probes."
-    - name: "ENABLE_ACCESS_LOG"
-      example: "true"
-      description: "Enable the Access Log."
-    - name: "ENABLE_JSON_LOGGING"
-      example: "true"
-      description: "Enable JSON-formatted logging"
     - name: "GIT_HOOKS_DIR"
       example: "/opt/git/hooks"
       description: "If provided, the specified path will be copied to all the git repositories hooks dir"
@@ -301,31 +237,8 @@ modules:
 packages:
       repositories:
           - jboss-os
-          - jboss-rhscl
       install:
-          - hostname
-          - mysql-connector-java
-          - postgresql-jdbc
-          - python-enum34
-          - python-requests
-          - PyYAML
-          - rh-mongodb32-mongo-java-driver
           - git
-artifacts:
-    - path: javax.json-1.0.4.jar
-      md5: 569870f975deeeb6691fcb9bc02a9555
-    - path: jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar
-      md5: 3c84f54725ea5657913cf6d1610798b0
-    - path: oauth-20100527.jar
-      md5: 91c7c70579f95b7ddee95b2143a49b41
-    - path: activemq-rar-5.11.0.redhat-630329.rar
-      md5: 76ed338d86bb3dbba2d4bd48daff7dbb
-    - path: rh-sso-7.1.0-eap7-adapter.zip
-      description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=44831&product=core.service.rhsso&version=7.0&downloadType=distributions"
-      sha256: 3d12e310a9b15f79cd46255819a0198acd569921797204c0936772e71dec8d23
-    - path: rh-sso-7.1.2-saml-eap7-adapter.zip
-      description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=44801&product=core.service.rhsso&version=7.0&downloadType=distributions"
-      sha256: f48b2b15ccfd17589f5a424c689697b8cfefbe95a553ba589c14eaba4978a823
 run:
       user: 185
       cmd:

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -18,78 +18,12 @@ labels:
     - name: "io.openshift.s2i.scripts-url"
       value: "image:///usr/local/s2i"
 envs:
-    - name: "STI_BUILDER"
-      value: "jee"
-    - name: "JBOSS_MODULES_SYSTEM_PKGS"
-      value: "org.jboss.logmanager,jdk.nashorn.api"
-    - name: "DEFAULT_ADMIN_USERNAME"
-      value: "eapadmin"
-    - name: "JAVA_OPTS_APPEND"
-      example: "-Dfoo=bar"
-      description: "Server startup options."
-    - name: "JBOSS_MODULES_SYSTEM_PKGS_APPEND"
-      example: "org.jboss.byteman"
-      description: "Comma-separated list of package names that will be appended to the JBOSS_MODULES_SYSTEM_PKGS environment variable."
-    - name: "MQ_SIMPLE_DEFAULT_PHYSICAL_DESTINATION"
-      example: "false"
-      description: "For backwards compatability, set to true to use 'MyQueue' and 'MyTopic' as physical destination name defaults instead of 'queue/MyQueue' and 'topic/MyTopic'."
-    - name: "DEFAULT_JMS_CONNECTION_FACTORY"
-      example: "java:jboss/DefaultJMSConnectionFactory"
-      description: "Specify the default JNDI binding for the JMS connection factory (jms-connection-factory='java:jboss/DefaultJMSConnectionFactory')."
-    - name: "CLI_GRACEFUL_SHUTDOWN"
-      example: "true"
-      description: "If set to any non zero length value then the image will prevent shutdown with the TERM signal and will require execution of the shutdown command through jboss-cli."
     - name: "SCRIPT_DEBUG"
       example: "true"
       description: "If set to true, ensurses that the bash scripts are executed with the -x option, printing the commands and their arguments as they are executed."
-    - name: "JAVA_MAX_MEM_RATIO"
-      example: "50"
-      description: "This is used to calculate a default maximal heap memory based on a containers restriction. If used in a container without any memory constraints for the container then this option has no effect. If there is a memory constraint then `-Xmx` is set to a ratio of the container available memory as set here. The default is `50` which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0` in which case no `-Xmx` option is added."
-    - name: "JAVA_INITIAL_MEM_RATIO"
-      example: "100"
-      description: "This is used to calculate a default initial heap memory based the maximal heap memory.  The default is `100` which means 100% of the maximal heap is used for the initial heap size.  You can skip this mechanism by setting this value to `0` in which case no `-Xms` option is added."
-    - name: "JAVA_MAX_INITIAL_MEM"
-      example: "4096"
-      description: "The maximum size of the initial heap memory, if the calculated default initial heap is larger then it will be capped at this value.  The default is 4096 MB."
-    - name: "JAVA_CORE_LIMIT"
-      example: "2"
-      description: "Core limit as described in https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt.  Used to configure the number of GC threads and parallelism for ForkJoinPool.  Defaults to container core limit."
-    - name: "JAVA_DIAGNOSTICS"
-      example: "true"
-      description: "Set this to get some diagnostics information to standard output when things are happening. **Disabled by default.**"
-    - name: "GC_MIN_HEAP_FREE_RATIO"
-      example: "20"
-      description: "Minimum percentage of heap free after GC to avoid expansion."
-    - name: "GC_MAX_HEAP_FREE_RATIO"
-      example: "40"
-      description: "Maximum percentage of heap free after GC to avoid shrinking."
-    - name: "GC_TIME_RATIO"
-      example: "4"
-      description: "Specifies the ratio of the time spent outside the garbage collection (for example, the time spent for application execution) to the time spent in the garbage collection."
-    - name: "GC_ADAPTIVE_SIZE_POLICY_WEIGHT"
-      example: "90"
-      description: "The weighting given to the current GC time versus previous GC times."
-    - name: "GC_MAX_METASPACE_SIZE"
-      example: "100"
-      description: "The maximum metaspace size."
     - name: "CUSTOM_INSTALL_DIRECTORIES"
       example: "custom,shared"
       description: "A list of comma-separated directories used for installation and configuration of artifacts for the image during the S2I process."
-    - name: "CONTAINER_HEAP_PERCENT"
-      example: "0.5"
-      description: "Deprecated.  See JAVA_MAX_MEM_RATIO."
-    - name: "INITIAL_HEAP_PERCENT"
-      example: "0.5"
-      description: "Deprecated.  See JAVA_INITIAL_MEM_RATIO."
-    - name: "PROBE_DISABLE_BOOT_ERRORS_CHECK"
-      example: "true"
-      description: "Disable the boot errors check in the probes."
-    - name: "ENABLE_ACCESS_LOG"
-      example: "true"
-      description: "Enable the Access Log."
-    - name: "ENABLE_JSON_LOGGING"
-      example: "true"
-      description: "Enable JSON-formatted logging"
     - name: "KIE_SERVER_ID"
       example: "my-kie-server"
       description: "KIE execution server identifier (Used to set the org.kie.server.id system property), If empty it will be auto generated."
@@ -354,33 +288,7 @@ modules:
           - name: os-logging
           - name: os.bpmsuite.common
           - name: os.bpmsuite.executionserver
-packages:
-      repositories:
-          - jboss-os
-          - jboss-rhscl
-      install:
-          - rh-mongodb32-mongo-java-driver
-          - postgresql-jdbc
-          - mysql-connector-java
-          - hostname
-          - python-requests
-          - python-enum34
-          - PyYAML
 artifacts:
-    - path: javax.json-1.0.4.jar
-      md5: 569870f975deeeb6691fcb9bc02a9555
-    - path: jboss-logmanager-ext-1.0.0.Alpha5-redhat-1.jar
-      md5: 3c84f54725ea5657913cf6d1610798b0
-    - path: oauth-20100527.jar
-      md5: 91c7c70579f95b7ddee95b2143a49b41
-    - path: activemq-rar-5.11.0.redhat-630329.rar
-      md5: 76ed338d86bb3dbba2d4bd48daff7dbb
-    - path: rh-sso-7.1.0-eap7-adapter.zip
-      description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=44831&product=core.service.rhsso&version=7.0&downloadType=distributions"
-      sha256: 3d12e310a9b15f79cd46255819a0198acd569921797204c0936772e71dec8d23
-    - path: rh-sso-7.1.2-saml-eap7-adapter.zip
-      description: "Artifact is available on Customer Portal: https://access.redhat.com/jbossnetwork/restricted/softwareDetail.html?softwareId=44801&product=core.service.rhsso&version=7.0&downloadType=distributions"
-      sha256: f48b2b15ccfd17589f5a424c689697b8cfefbe95a553ba589c14eaba4978a823
     - url: slf4j-simple-1.7.22.redhat-1.jar
       md5: 51c319582c16a07c21e41737e45cb03a
 run:


### PR DESCRIPTION
https://issues.jboss.org/browse/CLOUD-2413

This removes material from image.yaml that has been added to corresponding
modules in cct_module (in a corresponding PR)

The net result on the generated image is an effective no-op (some things
are reordered, such as environment variable definitions, which does not
affect the final image)

Signed-off-by: Jonathan Dowland <jdowland@redhat.com>