### PR TITLE
[RHDM-592] - Fix invalid value in template yaml

### DIFF
--- a/templates/rhdm70-kieserver-basic-s2i.yaml
+++ b/templates/rhdm70-kieserver-basic-s2i.yaml
@@ -165,7 +165,7 @@ parameters:
   description: Disable management api and don't allow KIE containers to be deployed/undeployed or started/stopped sets the property org.kie.server.mgmt.api.disabled to true and org.kie.server.startup.strategy to LocalContainersStartupStrategy.
   name: KIE_SERVER_MGMT_DISABLED
   required: true
-  value: true
+  value: "true"
 - displayName: Execution Server Container Memory Limit
   description: Execution Server Container memory limit
   name: EXCECUTION_SERVER_MEMORY_LIMIT

--- a/templates/rhdm70-kieserver-https-s2i.yaml
+++ b/templates/rhdm70-kieserver-https-s2i.yaml
@@ -192,7 +192,7 @@ parameters:
   description: Disable management api and don't allow KIE containers to be deployed/undeployed or started/stopped sets the property org.kie.server.mgmt.api.disabled to true and org.kie.server.startup.strategy to LocalContainersStartupStrategy.
   name: KIE_SERVER_MGMT_DISABLED
   required: true
-  value: true
+  value: "true"
 - displayName: Execution Server Container Memory Limit
   description: Execution Server Container memory limit
   name: EXCECUTION_SERVER_MEMORY_LIMIT


### PR DESCRIPTION
To fix an error :
oc create -f rhdm70-kieserver-https-s2i.yaml 
Error from server (BadRequest): error when creating "rhdm70-kieserver-https-s2i.yaml": Template in version "v1" cannot be handled as a Template: [pos 14188]: json: expect char '"' but got char 't'