### PR TITLE
[RHDM-608] rhdm70-dev branch should use CE sprint-18

### DIFF
--- a/decisioncentral/image.yaml
+++ b/decisioncentral/image.yaml
@@ -140,7 +140,7 @@ modules:
       repositories:
           - git:
               url: https://github.com/jboss-openshift/cct_module.git
-              ref: master
+              ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -197,7 +197,7 @@ modules:
       repositories:
           - git:
               url: https://github.com/jboss-openshift/cct_module.git
-              ref: master
+              ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
               ref: master


### PR DESCRIPTION
[RHDM-608] rhdm70-dev branch should use CE sprint-18
https://issues.jboss.org/browse/RHDM-608

Signed-off-by: David Ward <dward@redhat.com>