### PR TITLE
[RHDM-630] Update RHDM OpenShift images from 7.0.1.CR1 to 7.0.1.CR2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# rhdm-7-openshift-image
+Red Hat Decision Manager 7 OpenShift images
+

--- a/decisioncentral/image.yaml
+++ b/decisioncentral/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "rhdm-7/rhdm70-decisioncentral-openshift"
 description: "Red Hat Decision Manager Central 7.0 OpenShift container image"
-version: "1.0"
+version: "1.1"
 from: "rhdm-7/rhdm70-decisioncentral:latest"
 labels:
     - name: "com.redhat.component"
@@ -143,7 +143,7 @@ modules:
               ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
-              ref: master
+              ref: rhdm-7.0.1.GA
       install:
           - name: dynamic-resources
           - name: java-alternatives

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -2,7 +2,7 @@ schema_version: 1
 
 name: "rhdm-7/rhdm70-kieserver-openshift"
 description: "Red Hat Decision Manager Kie Server 7.0 container image"
-version: "1.0"
+version: "1.1"
 from: "rhdm-7/rhdm70-kieserver:latest"
 labels:
     - name: "com.redhat.component"
@@ -200,7 +200,7 @@ modules:
               ref: sprint-18
           - git:
               url: https://github.com/jboss-container-images/jboss-kie-modules.git
-              ref: master
+              ref: rhdm-7.0.1.GA
       install:
           - name: dynamic-resources
           - name: s2i-common

--- a/rhdm70-image-streams.yaml
+++ b/rhdm70-image-streams.yaml
@@ -25,6 +25,16 @@ items:
       from:
         kind: DockerImage
         name: registry.access.redhat.com/rhdm-7/rhdm70-decisioncentral-openshift:1.0
+    - name: '1.1'
+      annotations:
+        description: Red Hat Decision Manager 7.0 - Decision Central image.
+        iconClass: icon-jboss
+        tags: rhdm,xpaas
+        supports: rhdm:7.0,xpaas:1.4
+        version: '1.1'
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/rhdm-7/rhdm70-decisioncentral-openshift:1.1
 - kind: ImageStream
   apiVersion: v1
   metadata:
@@ -44,3 +54,13 @@ items:
       from:
         kind: DockerImage
         name: registry.access.redhat.com/rhdm-7/rhdm70-kieserver-openshift:1.0
+    - name: '1.1'
+      annotations:
+        description: Red Hat Decision Manager 7.0 - KIE Server image.
+        iconClass: icon-jboss
+        tags: rhdm,xpaas
+        supports: rhdm:7.0,xpaas:1.4
+        version: '1.1'
+      from:
+        kind: DockerImage
+        name: registry.access.redhat.com/rhdm-7/rhdm70-kieserver-openshift:1.1

--- a/templates/rhdm70-full.yaml
+++ b/templates/rhdm70-full.yaml
@@ -169,6 +169,11 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: ImageStream Tag
+  description: A named pointer to an image in an image stream. Default is "1.1".
+  name: IMAGE_STREAM_TAG
+  value: "1.1"
+  required: false
 - displayName: Maven repository URL
   description: Fully qualified URL to a Maven repository. If this parameter is unspecified, Decision Server uses 
    the repository provided by Decision Central.
@@ -346,7 +351,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: rhdm70-decisioncentral-openshift:1.0
+          name: "rhdm70-decisioncentral-openshift:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:
@@ -456,7 +461,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: rhdm70-kieserver-openshift:1.0
+          name: "rhdm70-kieserver-openshift:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:

--- a/templates/rhdm70-kieserver-basic-s2i.yaml
+++ b/templates/rhdm70-kieserver-basic-s2i.yaml
@@ -131,6 +131,11 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: ImageStream Tag
+  description: A named pointer to an image in an image stream. Default is "1.1".
+  name: IMAGE_STREAM_TAG
+  value: "1.1"
+  required: false
 - displayName: Maven mirror URL
   description: Maven mirror to use for S2I builds. If the Maven build of your decision service pulls packages 
     from a Maven repository, you can set this parameter. In this case, the build process will pull packages 
@@ -237,7 +242,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: rhdm70-kieserver-openshift:1.0
+          name: "rhdm70-kieserver-openshift:${IMAGE_STREAM_TAG}"
     output:
       to:
         kind: ImageStreamTag

--- a/templates/rhdm70-kieserver-https-s2i.yaml
+++ b/templates/rhdm70-kieserver-https-s2i.yaml
@@ -158,6 +158,11 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: ImageStream Tag
+  description: A named pointer to an image in an image stream. Default is "1.1".
+  name: IMAGE_STREAM_TAG
+  value: "1.1"
+  required: false
 - displayName: Maven mirror URL
   description: Maven mirror to use for S2I builds. If the Maven build of your decision service pulls packages 
     from a Maven repository, you can set this parameter. In this case, the build process will pull packages 
@@ -293,7 +298,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: rhdm70-kieserver-openshift:1.0
+          name: "rhdm70-kieserver-openshift:${IMAGE_STREAM_TAG}"
     output:
       to:
         kind: ImageStreamTag

--- a/templates/rhdm70-kieserver.yaml
+++ b/templates/rhdm70-kieserver.yaml
@@ -163,6 +163,11 @@ parameters:
   name: IMAGE_STREAM_NAMESPACE
   value: openshift
   required: true
+- displayName: ImageStream Tag
+  description: A named pointer to an image in an image stream. Default is "1.1".
+  name: IMAGE_STREAM_TAG
+  value: "1.1"
+  required: false
 - displayName: KIE Server Container Deployment
   description: 'KIE Server Container deployment configuration in format: containerId=groupId:artifactId:version|c2=g2:a2:v2'
   name: KIE_SERVER_CONTAINER_DEPLOYMENT
@@ -264,7 +269,7 @@ objects:
         from:
           kind: ImageStreamTag
           namespace: "${IMAGE_STREAM_NAMESPACE}"
-          name: rhdm70-kieserver-openshift:1.0
+          name: "rhdm70-kieserver-openshift:${IMAGE_STREAM_TAG}"
     - type: ConfigChange
     replicas: 1
     selector:


### PR DESCRIPTION
[RHDM-630] Update RHDM OpenShift images from 7.0.1.CR1 to 7.0.1.CR2
https://issues.jboss.org/browse/RHDM-630

Signed-off-by: David Ward <dward@redhat.com>