### PR TITLE
[RHDM-708] Replace scripts in probes for Kie Server Image with REST calls

### DIFF
--- a/templates/rhdm71-full.yaml
+++ b/templates/rhdm71-full.yaml
@@ -459,10 +459,6 @@ objects:
             value: "${DECISION_CENTRAL_HTTPS_NAME}"
           - name: HTTPS_PASSWORD
             value: "${DECISION_CENTRAL_HTTPS_PASSWORD}"
-          - name: PROBE_IMPL
-            value: probe.eap.jolokia.EapProbe
-          - name: PROBE_DISABLE_BOOT_ERRORS_CHECK
-            value: 'true'
         volumes:
         - name: decisioncentral-keystore-volume
           secret:
@@ -518,13 +514,21 @@ objects:
               command:
               - "/bin/bash"
               - "-c"
-              - "/opt/eap/bin/livenessProbe.sh"
+              - "curl --fail --silent -u '${KIE_ADMIN_USER}:${KIE_ADMIN_PWD}' http://localhost:8080/services/rest/server/healthcheck"
+            initialDelaySeconds: 180
+            timeoutSeconds: 2
+            periodSeconds: 15
+            failureThreshold: 3
           readinessProbe:
             exec:
               command:
               - "/bin/bash"
               - "-c"
-              - "/opt/eap/bin/readinessProbe.sh"
+              - "curl --fail --silent -u '${KIE_ADMIN_USER}:${KIE_ADMIN_PWD}' http://localhost:8080/services/rest/server/readycheck"
+            initialDelaySeconds: 60
+            timeoutSeconds: 2
+            periodSeconds: 30
+            failureThreshold: 6
           ports:
           - name: jolokia
             containerPort: 8778

--- a/templates/rhdm71-kieserver-basic-s2i.yaml
+++ b/templates/rhdm71-kieserver-basic-s2i.yaml
@@ -289,13 +289,21 @@ objects:
               command:
               - "/bin/bash"
               - "-c"
-              - "/opt/eap/bin/livenessProbe.sh"
+              - "curl --fail --silent -u '${KIE_ADMIN_USER}:${KIE_ADMIN_PWD}' http://localhost:8080/services/rest/server/healthcheck"
+            initialDelaySeconds: 180
+            timeoutSeconds: 2
+            periodSeconds: 15
+            failureThreshold: 3
           readinessProbe:
             exec:
               command:
               - "/bin/bash"
               - "-c"
-              - "/opt/eap/bin/readinessProbe.sh"
+              - "curl --fail --silent -u '${KIE_ADMIN_USER}:${KIE_ADMIN_PWD}' http://localhost:8080/services/rest/server/readycheck"
+            initialDelaySeconds: 60
+            timeoutSeconds: 2
+            periodSeconds: 30
+            failureThreshold: 6
           ports:
           - name: jolokia
             containerPort: 8778

--- a/templates/rhdm71-kieserver-https-s2i.yaml
+++ b/templates/rhdm71-kieserver-https-s2i.yaml
@@ -349,13 +349,21 @@ objects:
               command:
               - "/bin/bash"
               - "-c"
-              - "/opt/eap/bin/livenessProbe.sh"
+              - "curl --fail --silent -u '${KIE_ADMIN_USER}:${KIE_ADMIN_PWD}' http://localhost:8080/services/rest/server/healthcheck"
+            initialDelaySeconds: 180
+            timeoutSeconds: 2
+            periodSeconds: 15
+            failureThreshold: 3
           readinessProbe:
             exec:
               command:
               - "/bin/bash"
               - "-c"
-              - "/opt/eap/bin/readinessProbe.sh"
+              - "curl --fail --silent -u '${KIE_ADMIN_USER}:${KIE_ADMIN_PWD}' http://localhost:8080/services/rest/server/readycheck"
+            initialDelaySeconds: 60
+            timeoutSeconds: 2
+            periodSeconds: 30
+            failureThreshold: 6
           ports:
           - name: jolokia
             containerPort: 8778

--- a/templates/rhdm71-kieserver.yaml
+++ b/templates/rhdm71-kieserver.yaml
@@ -319,13 +319,21 @@ objects:
               command:
               - "/bin/bash"
               - "-c"
-              - "/opt/eap/bin/livenessProbe.sh"
+              - "curl --fail --silent -u '${KIE_ADMIN_USER}:${KIE_ADMIN_PWD}' http://localhost:8080/services/rest/server/healthcheck"
+            initialDelaySeconds: 180
+            timeoutSeconds: 2
+            periodSeconds: 15
+            failureThreshold: 3
           readinessProbe:
             exec:
               command:
               - "/bin/bash"
               - "-c"
-              - "/opt/eap/bin/readinessProbe.sh"
+              - "curl --fail --silent -u '${KIE_ADMIN_USER}:${KIE_ADMIN_PWD}' http://localhost:8080/services/rest/server/readycheck"
+            initialDelaySeconds: 60
+            timeoutSeconds: 2
+            periodSeconds: 30
+            failureThreshold: 6
           ports:
           - name: jolokia
             containerPort: 8778


### PR DESCRIPTION
[RHDM-708] Replace scripts in probes for Kie Server Image with REST calls
https://issues.jboss.org/browse/RHDM-708

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
