### PR TITLE
[RHDM-722] GIT_HOOKS_DIR parameter not exposed in RHDM templates

### DIFF
--- a/templates/rhdm71-full.yaml
+++ b/templates/rhdm71-full.yaml
@@ -202,6 +202,11 @@ parameters:
   from: "[a-zA-Z]{6}[0-9]{1}!"
   generate: expression
   required: true
+- displayName: Git hooks directory
+  description: The directory to use for git hooks, if required.
+  name: GIT_HOOKS_DIR
+  example: /opt/git/hooks
+  required: false
 - displayName: Decision Central Volume Capacity
   description: Size of the persistent storage for Decision Central's runtime data.
   name: DECISION_CENTRAL_VOLUME_CAPACITY
@@ -464,6 +469,8 @@ objects:
             value: "${DECISION_CENTRAL_MAVEN_USERNAME}"
           - name: KIE_MAVEN_PWD
             value: "${DECISION_CENTRAL_MAVEN_PASSWORD}"
+          - name: GIT_HOOKS_DIR
+            value: "${GIT_HOOKS_DIR}"
           - name: HTTPS_KEYSTORE_DIR
             value: "/etc/decisioncentral-secret-volume"
           - name: HTTPS_KEYSTORE


### PR DESCRIPTION
[RHDM-722] GIT_HOOKS_DIR parameter not exposed in RHDM templates
https://issues.jboss.org/browse/RHDM-722

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
