### PR TITLE
[RHDM-735] RHDM maven repository id should be configurable instead of generated

### DIFF
--- a/templates/rhdm71-authoring-ha.yaml
+++ b/templates/rhdm71-authoring-ha.yaml
@@ -281,6 +281,11 @@ parameters:
   name: IMAGE_STREAM_TAG
   value: "1.0"
   required: true
+- displayName: Maven repository ID
+  description: The id to use for the maven repository, if set. Default is generated randomly.
+  name: MAVEN_REPO_ID
+  example: my-repo-id
+  required: false
 - displayName: Maven repository URL
   description: Fully qualified URL to a Maven repository or service.
   name: MAVEN_REPO_URL
@@ -763,6 +768,8 @@ objects:
             value: "${KIE_SERVER_PWD}"
           - name: WORKBENCH_ROUTE_NAME
             value: "${APPLICATION_NAME}-rhdmcentr"
+          - name: MAVEN_REPO_ID
+            value: "${MAVEN_REPO_ID}"
           - name: MAVEN_REPO_URL
             value: "${MAVEN_REPO_URL}"
           - name: MAVEN_REPO_USERNAME
@@ -994,6 +1001,8 @@ objects:
             value: "${DECISION_CENTRAL_MAVEN_USERNAME}"
           - name: RHDMCENTR_MAVEN_REPO_PASSWORD
             value: "${DECISION_CENTRAL_MAVEN_PASSWORD}"
+          - name: EXTERNAL_MAVEN_REPO_ID
+            value: "${MAVEN_REPO_ID}"
           - name: EXTERNAL_MAVEN_REPO_URL
             value: "${MAVEN_REPO_URL}"
           - name: EXTERNAL_MAVEN_REPO_USERNAME

--- a/templates/rhdm71-authoring.yaml
+++ b/templates/rhdm71-authoring.yaml
@@ -185,6 +185,11 @@ parameters:
   name: IMAGE_STREAM_TAG
   value: "1.0"
   required: true
+- displayName: Maven repository ID
+  description: The id to use for the maven repository, if set. Default is generated randomly.
+  name: MAVEN_REPO_ID
+  example: my-repo-id
+  required: false
 - displayName: Maven repository URL
   description: Fully qualified URL to a Maven repository or service.
   name: MAVEN_REPO_URL
@@ -602,6 +607,8 @@ objects:
             value: "${KIE_SERVER_PWD}"
           - name: WORKBENCH_ROUTE_NAME
             value: "${APPLICATION_NAME}-rhdmcentr"
+          - name: MAVEN_REPO_ID
+            value: "${MAVEN_REPO_ID}"
           - name: MAVEN_REPO_URL
             value: "${MAVEN_REPO_URL}"
           - name: MAVEN_REPO_USERNAME
@@ -813,6 +820,8 @@ objects:
             value: "${DECISION_CENTRAL_MAVEN_USERNAME}"
           - name: RHDMCENTR_MAVEN_REPO_PASSWORD
             value: "${DECISION_CENTRAL_MAVEN_PASSWORD}"
+          - name: EXTERNAL_MAVEN_REPO_ID
+            value: "${MAVEN_REPO_ID}"
           - name: EXTERNAL_MAVEN_REPO_URL
             value: "${MAVEN_REPO_URL}"
           - name: EXTERNAL_MAVEN_REPO_USERNAME

--- a/templates/rhdm71-kieserver.yaml
+++ b/templates/rhdm71-kieserver.yaml
@@ -31,6 +31,11 @@ parameters:
   name: APPLICATION_NAME
   value: myapp
   required: true
+- displayName: Maven repository ID
+  description: The id to use for the maven repository, if set. Default is generated randomly.
+  name: MAVEN_REPO_ID
+  example: my-repo-id
+  required: false
 - displayName: Maven repository URL
   description: Fully qualified URL to a Maven repository or service.
   name: MAVEN_REPO_URL
@@ -570,6 +575,8 @@ objects:
             value: "${DECISION_CENTRAL_MAVEN_USERNAME}"
           - name: RHDMCENTR_MAVEN_REPO_PASSWORD
             value: "${DECISION_CENTRAL_MAVEN_PASSWORD}"
+          - name: EXTERNAL_MAVEN_REPO_ID
+            value: "${MAVEN_REPO_ID}"
           - name: EXTERNAL_MAVEN_REPO_URL
             value: "${MAVEN_REPO_URL}"
           - name: EXTERNAL_MAVEN_REPO_USERNAME

--- a/templates/rhdm71-prod-immutable-kieserver.yaml
+++ b/templates/rhdm71-prod-immutable-kieserver.yaml
@@ -196,6 +196,11 @@ parameters:
   description: Maven mirror to use for S2I builds
   name: MAVEN_MIRROR_URL
   required: false
+- displayName: Maven repository ID
+  description: The id to use for the maven repository, if set. Default is generated randomly.
+  name: MAVEN_REPO_ID
+  example: my-repo-id
+  required: false
 - displayName: Maven repository URL
   description: Fully qualified URL to a Maven repository.
   name: MAVEN_REPO_URL
@@ -656,6 +661,8 @@ objects:
             value: "${DECISION_CENTRAL_MAVEN_USERNAME}"
           - name: RHDMCENTR_MAVEN_REPO_PASSWORD
             value: "${DECISION_CENTRAL_MAVEN_PASSWORD}"
+          - name: EXTERNAL_MAVEN_REPO_ID
+            value: "${MAVEN_REPO_ID}"
           - name: EXTERNAL_MAVEN_REPO_URL
             value: "${MAVEN_REPO_URL}"
           - name: EXTERNAL_MAVEN_REPO_USERNAME

--- a/templates/rhdm71-trial-ephemeral.yaml
+++ b/templates/rhdm71-trial-ephemeral.yaml
@@ -115,6 +115,11 @@ parameters:
   name: KIE_SERVER_CONTAINER_DEPLOYMENT
   value: ''
   required: false
+- displayName: Maven repository ID
+  description: The id to use for the maven repository, if set. Default is generated randomly.
+  name: MAVEN_REPO_ID
+  example: my-repo-id
+  required: false
 - displayName: Maven repository URL
   description: Fully qualified URL to a Maven repository or service.
   name: MAVEN_REPO_URL
@@ -464,6 +469,8 @@ objects:
             value: "${DEFAULT_PASSWORD}"
           - name: WORKBENCH_ROUTE_NAME
             value: "${APPLICATION_NAME}-rhdmcentr"
+          - name: MAVEN_REPO_ID
+            value: "${MAVEN_REPO_ID}"
           - name: MAVEN_REPO_URL
             value: "${MAVEN_REPO_URL}"
           - name: MAVEN_REPO_USERNAME
@@ -649,6 +656,8 @@ objects:
             value: "${DECISION_CENTRAL_MAVEN_USERNAME}"
           - name: RHDMCENTR_MAVEN_REPO_PASSWORD
             value: "${DEFAULT_PASSWORD}"
+          - name: EXTERNAL_MAVEN_REPO_ID
+            value: "${MAVEN_REPO_ID}"
           - name: EXTERNAL_MAVEN_REPO_URL
             value: "${MAVEN_REPO_URL}"
           - name: EXTERNAL_MAVEN_REPO_USERNAME


### PR DESCRIPTION
[RHDM-735] RHDM maven repository id should be configurable instead of generated
https://issues.jboss.org/browse/RHDM-735

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
