### PR TITLE
Revert "[RHDM-761] - add decisionserver tag to dm templates to get it correct…"

### DIFF
--- a/templates/optaweb/rhdm71-optaweb-employee-rostering-trial-ephemeral.yaml
+++ b/templates/optaweb/rhdm71-optaweb-employee-rostering-trial-ephemeral.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhdm,decisionserver,jboss,optaweb,employee-rostering,trial
+    tags: rhdm,jboss,optaweb,employee-rostering,trial
     version: "1.0"
     openshift.io/display-name: Red Hat Decision Manager 7.1 Business Optimizer Employee Rostering ephemeral trial environment
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhdm71-authoring-ha.yaml
+++ b/templates/rhdm71-authoring-ha.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhdm,decisionserver,jboss,authoring,ha
+    tags: rhdm,jboss,authoring,ha
     version: "1.0"
     openshift.io/display-name: Red Hat Decision Manager 7.1 authoring environment (HA, persistent, with https)
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhdm71-authoring.yaml
+++ b/templates/rhdm71-authoring.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhdm,decisionserver,jboss,authoring
+    tags: rhdm,jboss,authoring
     version: "1.0"
     openshift.io/display-name: Red Hat Decision Manager 7.1 authoring environment (non-HA, persistent, with https)
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhdm71-kieserver.yaml
+++ b/templates/rhdm71-kieserver.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhdm,decisionserver,jboss,kieserver
+    tags: rhdm,jboss,kieserver
     version: "1.0"
     openshift.io/display-name: Red Hat Decision Manager 7.1 managed KIE Server
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhdm71-prod-immutable-kieserver.yaml
+++ b/templates/rhdm71-prod-immutable-kieserver.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhdm,decisionserver,jboss,kieserver,immutable,s2i
+    tags: rhdm,jboss,kieserver,immutable,s2i
     version: "1.0"
     openshift.io/display-name: Red Hat Decision Manager 7.1 immutable production environment
     openshift.io/provider-display-name: Red Hat, Inc.

--- a/templates/rhdm71-trial-ephemeral.yaml
+++ b/templates/rhdm71-trial-ephemeral.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 metadata:
   annotations:
     iconClass: icon-jboss
-    tags: rhdm,decisionserver,jboss,trial
+    tags: rhdm,jboss,trial
     version: "1.0"
     openshift.io/display-name: Red Hat Decision Manager 7.1 ephemeral trial environment
     openshift.io/provider-display-name: Red Hat, Inc.


### PR DESCRIPTION
Reverts jboss-container-images/rhdm-7-openshift-image#130

It was decided that we won't include this in 7.1.0, so reverting on the 7.1.x branch.