### PR TITLE
[RHPAM-1717] Update default vaule of PostgreSQL ImageStream Tag in OpenShift templates

### DIFF
--- a/templates/optaweb/rhdm72-optaweb-employee-rostering-postgresql.yaml
+++ b/templates/optaweb/rhdm72-optaweb-employee-rostering-postgresql.yaml
@@ -92,9 +92,9 @@ parameters:
   value: "openshift"
   required: false
 - displayName: PostgreSQL ImageStream Tag
-  description: The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "9.6".
+  description: The PostgreSQL image version, which is intended to correspond to the PostgreSQL version. Default is "10".
   name: POSTGRESQL_IMAGE_STREAM_TAG
-  value: "9.6"
+  value: "10"
   required: false
 - displayName: PostgreSQL Database max prepared connections
   description: Allows the PostgreSQL to handle XA transactions.


### PR DESCRIPTION
[RHPAM-1717] Update default vaule of PostgreSQL ImageStream Tag in OpenShift templates
https://issues.jboss.org/browse/RHPAM-1717

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
