### PR TITLE
[KIECLOUD-107] Add Prometheus config to EAP-based RHDM 7 images

### DIFF
--- a/controller/image.yaml
+++ b/controller/image.yaml
@@ -113,6 +113,8 @@ modules:
           - name: openshift-layer
           - name: openshift-passwd
           - name: os-logging
+          - name: jboss.container.eap.prometheus.config
+            version: '7.2'
           - name: jboss-kie-wildfly-common
           - name: jboss-kie-controller
 packages:

--- a/decisioncentral/image.yaml
+++ b/decisioncentral/image.yaml
@@ -161,6 +161,8 @@ modules:
           - name: openshift-layer
           - name: openshift-passwd
           - name: os-logging
+          - name: jboss.container.eap.prometheus.config
+            version: '7.2'
           - name: jboss-kie-wildfly-common
           - name: jboss-kie-workbench
 packages:

--- a/kieserver/image.yaml
+++ b/kieserver/image.yaml
@@ -121,18 +121,9 @@ envs:
     - name: "KIE_SERVER_CONTROLLER_TOKEN"
       example: "dasd373egds"
       description: "KIE server controller token for bearer authentication (Sets the org.kie.server.controller.token system property)"
-    - name: "KIE_SERVER_ROUTER_SERVICE"
-      example: "smartrouter-myapp"
-      description: "KIE server router service (Used to set the org.kie.server.router system property if host and port aren't set)"
-    - name: "KIE_SERVER_ROUTER_PROTOCOL"
-      example: "http"
-      description: "KIE server router protocol (Used to set the org.kie.server.router system property)"
-    - name: "KIE_SERVER_ROUTER_HOST"
-      example: "my-app-router.os.mycloud.com"
-      description: "KIE server router host (Used to set the org.kie.server.router system property)"
-    - name: "KIE_SERVER_ROUTER_PORT"
-      example: "9000"
-      description: "KIE server router port (Used to set the org.kie.server.router system property)"
+    - name: "PROMETHEUS_SERVER_EXT_DISABLED"
+      example: "false"
+      description: "If set to false, the prometheus server extension will be enabled. (Sets the org.kie.prometheus.server.ext.disabled system property)"
 ports:
     - value: 8080
     - value: 8443
@@ -197,6 +188,8 @@ modules:
           - name: openshift-layer
           - name: openshift-passwd
           - name: os-logging
+          - name: jboss.container.eap.prometheus.config
+            version: '7.2'
           - name: jboss-kie-wildfly-common
           - name: jboss-kie-kieserver
 packages:

--- a/optaweb-employee-rostering/image.yaml
+++ b/optaweb-employee-rostering/image.yaml
@@ -95,6 +95,8 @@ modules:
           - name: openshift-layer
           - name: openshift-passwd
           - name: os-logging
+          - name: jboss.container.eap.prometheus.config
+            version: '7.2'
           - name: jboss-kie-wildfly-common
           - name: jboss-kie-optaweb-common
           - name: jboss-kie-optaweb-employeerostering

--- a/templates/rhdm73-trial-ephemeral.yaml
+++ b/templates/rhdm73-trial-ephemeral.yaml
@@ -71,6 +71,11 @@ parameters:
   name: DROOLS_SERVER_FILTER_CLASSES
   value: 'true'
   required: false
+- displayName: Prometheus Server Extension Disabled
+  description: If set to false, the prometheus server extension will be enabled. (Sets the org.kie.prometheus.server.ext.disabled system property)
+  name: PROMETHEUS_SERVER_EXT_DISABLED
+  example: 'false'
+  required: false
 - displayName: KIE Server Custom http Route Hostname
   description: 'Custom hostname for http service route. Leave blank for default hostname,
     e.g.: <application-name>-kieserver-<project>.<default-domain-suffix>'
@@ -648,6 +653,8 @@ objects:
           env:
           - name: DROOLS_SERVER_FILTER_CLASSES
             value: "${DROOLS_SERVER_FILTER_CLASSES}"
+          - name: PROMETHEUS_SERVER_EXT_DISABLED
+            value: "${PROMETHEUS_SERVER_EXT_DISABLED}"
           - name: KIE_ADMIN_USER
             value: "${KIE_ADMIN_USER}"
           - name: KIE_ADMIN_PWD


### PR DESCRIPTION
[KIECLOUD-107] Add Prometheus module to EAP-based RHDM 7 images
https://issues.jboss.org/browse/KIECLOUD-107

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
