### PR TITLE
[KIECLOUD-114] Remove app label from authoring HA template

### DIFF
--- a/templates/rhdm73-authoring-ha.yaml
+++ b/templates/rhdm73-authoring-ha.yaml
@@ -492,7 +492,6 @@ objects:
   metadata:
     name: ${APPLICATION_NAME}-amq-role
     labels:
-      app: ${APPLICATION_NAME}
       application: ${APPLICATION_NAME}
   rules:
   - apiGroups:
@@ -520,7 +519,6 @@ objects:
   metadata:
     name: ${APPLICATION_NAME}-amq-scaledown-controller-role
     labels:
-      app: ${APPLICATION_NAME}
       application: ${APPLICATION_NAME}
   rules:
   - apiGroups:
@@ -565,7 +563,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-rhdmsvc"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
 - kind: RoleBinding
   apiVersion: v1
@@ -596,7 +593,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-rhdmcentr"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-rhdmcentr"
     annotations:
@@ -614,7 +610,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-ping"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
     annotations:
       service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
@@ -634,7 +629,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-kieserver"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
@@ -654,7 +648,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-rhdmindex"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-rhdmindex"
     annotations:
@@ -671,7 +664,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-amq-tcp"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-amq"
     annotations:
@@ -683,7 +675,6 @@ objects:
       description: The JGroups ping port for clustering.
       service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
     labels:
-      app: ${APPLICATION_NAME}
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}-amq-ping
   spec:
@@ -700,7 +691,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-rhdmcentr"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-rhdmcentr"
     annotations:
@@ -718,7 +708,6 @@ objects:
   metadata:
     name: "secure-${APPLICATION_NAME}-rhdmcentr"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-rhdmcentr"
     annotations:
@@ -738,7 +727,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-kieserver"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
@@ -755,7 +743,6 @@ objects:
   metadata:
     name: "secure-${APPLICATION_NAME}-kieserver"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
@@ -774,7 +761,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-rhdmindex"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
     annotations:
       description: Route for Decision Central Indexing's Elasticsearch http service.
@@ -789,7 +775,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-rhdmcentr"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-rhdmcentr"
     annotations:
@@ -816,7 +801,6 @@ objects:
       metadata:
         name: "${APPLICATION_NAME}-rhdmcentr"
         labels:
-          app: ${APPLICATION_NAME}
           deploymentConfig: "${APPLICATION_NAME}-rhdmcentr"
           application: "${APPLICATION_NAME}"
       spec:
@@ -1010,7 +994,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-kieserver"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-kieserver"
     annotations:
@@ -1036,7 +1019,6 @@ objects:
       metadata:
         name: "${APPLICATION_NAME}-kieserver"
         labels:
-          app: ${APPLICATION_NAME}
           deploymentConfig: "${APPLICATION_NAME}-kieserver"
           application: "${APPLICATION_NAME}"
       spec:
@@ -1217,7 +1199,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-rhdmindex"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
       service: "${APPLICATION_NAME}-rhdmindex"
     annotations:
@@ -1296,7 +1277,6 @@ objects:
   apiVersion: v1
   metadata:
     labels:
-      app: ${APPLICATION_NAME}
       application: ${APPLICATION_NAME}
       service: ${APPLICATION_NAME}-amq-scaledown-controller
     name: ${APPLICATION_NAME}-amq-scaledown-controller
@@ -1314,7 +1294,6 @@ objects:
     template:
       metadata:
         labels:
-          app: ${APPLICATION_NAME}
           application: ${APPLICATION_NAME}
           deploymentConfig: ${APPLICATION_NAME}-amq-scaledown-controller
         name: ${APPLICATION_NAME}-amq-scaledown-controller
@@ -1450,7 +1429,6 @@ objects:
     creationTimestamp: null
     generation: 3
     labels:
-      app: ${APPLICATION_NAME}
       application: ${APPLICATION_NAME}
     name: ${APPLICATION_NAME}-amq
   spec:
@@ -1459,13 +1437,12 @@ objects:
     revisionHistoryLimit: 10
     selector:
       matchLabels:
-        app: ${APPLICATION_NAME}
+        deploymentConfig: ${APPLICATION_NAME}-amq
     serviceName: ${APPLICATION_NAME}-amq-tcp
     template:
       metadata:
         creationTimestamp: null
         labels:
-          app: ${APPLICATION_NAME}
           application: ${APPLICATION_NAME}
           deploymentConfig: ${APPLICATION_NAME}-amq
         name: ${APPLICATION_NAME}-amq
@@ -1562,7 +1539,6 @@ objects:
   metadata:
     name: ${APPLICATION_NAME}-amq-scaledown-controller-openshift-rb
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
   subjects:
     - kind: ServiceAccount
@@ -1576,7 +1552,6 @@ objects:
   metadata:
     name: ${APPLICATION_NAME}-amq-rb
     labels:
-      app: ${APPLICATION_NAME}
       application: ${APPLICATION_NAME}
   subjects:
     - kind: ServiceAccount
@@ -1589,14 +1564,12 @@ objects:
   kind: ServiceAccount
   metadata:
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
     name: ${APPLICATION_NAME}-amq-sa
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
     name: ${APPLICATION_NAME}-amq-scaledown-controller-sa
 - apiVersion: v1
@@ -1616,7 +1589,6 @@ objects:
   metadata:
     name: "${APPLICATION_NAME}-rhdmindex-claim"
     labels:
-      app: ${APPLICATION_NAME}
       application: "${APPLICATION_NAME}"
   spec:
     accessModes:


### PR DESCRIPTION
JIRA Link: https://issues.jboss.org/browse/KIECLOUD-114

After some discussion, instead of adding app labels in all templates, we decided to remove the app labels as they are automatically generated by OpenShift. Although I still believe we must change the application
label to another thing as app and application labels semantically mean the same.

Signed-off-by: rimolive <ricardo.martinelli.oliveira@gmail.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
