### PR TITLE
[RHDM-870] Fix AMQ ping service name

### DIFF
--- a/templates/rhdm73-authoring-ha.yaml
+++ b/templates/rhdm73-authoring-ha.yaml
@@ -695,13 +695,13 @@ objects:
     selector:
       deploymentConfig: ${APPLICATION_NAME}-amq
   metadata:
-    name: ${APPLICATION_NAME}-amq-ping
+    name: ping
     annotations:
       description: The JGroups ping port for clustering.
       service.alpha.kubernetes.io/tolerate-unready-endpoints: 'true'
     labels:
       application: ${APPLICATION_NAME}
-      service: ${APPLICATION_NAME}-amq-ping
+      service: ping
 - kind: Route
   apiVersion: v1
   id: "${APPLICATION_NAME}-rhdmcentr-http"
@@ -1436,7 +1436,7 @@ objects:
                   },
                   {
                     "name": "OPENSHIFT_DNS_PING_SERVICE_NAME",
-                    "value": "${APPLICATION_NAME}-amq-ping"
+                    "value": "ping"
                   },
                   {
                     "name": "OPENSHIFT_DNS_PING_SERVICE_PORT",


### PR DESCRIPTION
JIRA Link: https://issues.jboss.org/browse/RHDM-870

"ping" must be used as Service name as AMQ clustering configuration hard-coded this name.

Signed-off-by: rimolive <ricardo.martinelli.oliveira@gmail.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [X] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [X] Pull Request contains link to the JIRA issue
- [X] Pull Request contains description of the issue
- [X] Pull Request does not include fixes for issues other than the main ticket
- [X] Attached commits represent units of work and are properly formatted
- [X] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [X] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
