### PR TITLE
[KIECLOUD-148] (master) System property org.uberfire.nio.git.ssh.hostname not provided

### DIFF
--- a/templates/rhdm74-authoring-ha.yaml
+++ b/templates/rhdm74-authoring-ha.yaml
@@ -865,6 +865,9 @@ objects:
           - name: https
             containerPort: 8443
             protocol: TCP
+          - name: git-ssh
+            containerPort: 8001
+            protocol: TCP
           - name: ping
             containerPort: 8888
             protocol: TCP


### PR DESCRIPTION
[KIECLOUD-148] System property org.uberfire.nio.git.ssh.hostname not provided
https://issues.jboss.org/browse/KIECLOUD-148

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
