### PR TITLE
[KIECLOUD-159] Remove prometheus template params from trial-ephemeral templates in 7.3.0

### DIFF
--- a/templates/rhdm73-trial-ephemeral.yaml
+++ b/templates/rhdm73-trial-ephemeral.yaml
@@ -76,11 +76,6 @@ parameters:
   name: DROOLS_SERVER_FILTER_CLASSES
   value: 'true'
   required: false
-- displayName: Prometheus Server Extension Disabled
-  description: If set to false, the prometheus server extension will be enabled. (Sets the org.kie.prometheus.server.ext.disabled system property)
-  name: PROMETHEUS_SERVER_EXT_DISABLED
-  example: 'false'
-  required: false
 - displayName: KIE Server Custom http Route Hostname
   description: 'Custom hostname for http service route. Leave blank for default hostname,
     e.g.: <application-name>-kieserver-<project>.<default-domain-suffix>'
@@ -656,8 +651,6 @@ objects:
             containerPort: 8080
             protocol: TCP
           env:
-          - name: PROMETHEUS_SERVER_EXT_DISABLED
-            value: "${PROMETHEUS_SERVER_EXT_DISABLED}"
           - name: KIE_ADMIN_USER
             value: "${KIE_ADMIN_USER}"
           - name: KIE_ADMIN_PWD


### PR DESCRIPTION
[KIECLOUD-159] Remove prometheus template params from trial-ephemeral templates in 7.3.0
https://issues.jboss.org/browse/KIECLOUD-159 

Signed-off-by: David Ward <dward@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [ ] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [ ] Pull Request contains link to the JIRA issue
- [ ] Pull Request contains description of the issue
- [ ] Pull Request does not include fixes for issues other than the main ticket
- [ ] Attached commits represent units of work and are properly formatted
- [ ] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [ ] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
