### PR TITLE
[KIECLOUD-614] - Application Templates still referencing the AUTH_LDA…

### DIFF
--- a/templates/rhdm713-authoring-ha.yaml
+++ b/templates/rhdm713-authoring-ha.yaml
@@ -403,11 +403,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -974,8 +969,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN
@@ -1219,8 +1212,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhdm713-authoring.yaml
+++ b/templates/rhdm713-authoring.yaml
@@ -322,11 +322,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -684,8 +679,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN
@@ -927,8 +920,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhdm713-kieserver.yaml
+++ b/templates/rhdm713-kieserver.yaml
@@ -246,11 +246,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -592,8 +587,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhdm713-prod-immutable-kieserver-amq.yaml
+++ b/templates/rhdm713-prod-immutable-kieserver-amq.yaml
@@ -346,11 +346,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -929,8 +924,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhdm713-prod-immutable-kieserver.yaml
+++ b/templates/rhdm713-prod-immutable-kieserver.yaml
@@ -272,11 +272,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -669,8 +664,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN

--- a/templates/rhdm713-trial-ephemeral.yaml
+++ b/templates/rhdm713-trial-ephemeral.yaml
@@ -260,11 +260,6 @@ parameters:
     name: AUTH_LDAP_SEARCH_TIME_LIMIT
     example: "10000"
     required: false
-  - displayName: LDAP DN attribute
-    description: The name of the attribute in the user entry that contains the DN of the user. This may be necessary if the DN of the user itself contains special characters, backslash for example, that prevent correct user mapping. If the attribute does not exist, the entry’s DN is used.
-    name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-    example: "distinguishedName"
-    required: false
   - displayName: LDAP Role attributeID
     description: Name of the attribute containing the user roles.
     name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
@@ -537,8 +532,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN
@@ -729,8 +722,6 @@ objects:
                   value: "${AUTH_LDAP_RECURSIVE_SEARCH}"
                 - name: AUTH_LDAP_SEARCH_TIME_LIMIT
                   value: "${AUTH_LDAP_SEARCH_TIME_LIMIT}"
-                - name: AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE
-                  value: "${AUTH_LDAP_DISTINGUISHED_NAME_ATTRIBUTE}"
                 - name: AUTH_LDAP_ROLE_ATTRIBUTE_ID
                   value: "${AUTH_LDAP_ROLE_ATTRIBUTE_ID}"
                 - name: AUTH_LDAP_ROLES_CTX_DN


### PR DESCRIPTION
…P_DISTINGUISHED_NAME_ATTRIBUTE env
See: https://issues.redhat.com/browse/KIECLOUD-614
Cherry-picks: https://github.com/jboss-container-images/rhdm-7-openshift-image/pull/467

Signed-off-by: spolti <fspolti@redhat.com>

Thanks for submitting your Pull Request!

Please make sure your PR meets the following requirements:

- [x] Pull Request title is properly formatted: `[RHDM-XYZ] Subject`
- [x] Pull Request contains link to the JIRA issue
- [x] Pull Request contains description of the issue
- [x] Pull Request does not include fixes for issues other than the main ticket
- [x] Attached commits represent units of work and are properly formatted
- [x] You have read and agreed to the Developer Certificate of Origin (DCO) (see `CONTRIBUTING.md`)
- [x] Every commit contains `Signed-off-by: Your Name <yourname@example.com>` - use `git commit -s`
