### PR TITLE
Jira SO-48: Remove non-groupified API from rhdm-7-openshift-image

### DIFF
--- a/rhdm713-image-streams.yaml
+++ b/rhdm713-image-streams.yaml
@@ -1,5 +1,5 @@
 kind: ImageStreamList
-apiVersion: v1
+apiVersion: image.openshift.io/v1
 metadata:
   name: rhdm713-image-streams
   annotations:
@@ -7,7 +7,7 @@ metadata:
     openshift.io/provider-display-name: Red Hat, Inc.
 items:
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhdm-decisioncentral-rhel8
       annotations:
@@ -28,7 +28,7 @@ items:
             kind: DockerImage
             name: registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.13.0
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhdm-controller-rhel8
       annotations:
@@ -49,7 +49,7 @@ items:
             kind: DockerImage
             name: registry.redhat.io/rhdm-7/rhdm-controller-rhel8:7.13.0
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: rhdm-kieserver-rhel8
       annotations:

--- a/templates/rhdm713-authoring-ha.yaml
+++ b/templates/rhdm713-authoring-ha.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/rhdm713-authoring.yaml
+++ b/templates/rhdm713-authoring.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/rhdm713-kieserver.yaml
+++ b/templates/rhdm713-kieserver.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss

--- a/templates/rhdm713-prod-immutable-kieserver-amq.yaml
+++ b/templates/rhdm713-prod-immutable-kieserver-amq.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss
@@ -648,7 +648,7 @@ objects:
       tls:
         termination: passthrough
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: "${APPLICATION_NAME}-kieserver"
       labels:

--- a/templates/rhdm713-prod-immutable-kieserver.yaml
+++ b/templates/rhdm713-prod-immutable-kieserver.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss
@@ -396,7 +396,7 @@ objects:
       tls:
         termination: passthrough
   - kind: ImageStream
-    apiVersion: v1
+    apiVersion: image.openshift.io/v1
     metadata:
       name: "${APPLICATION_NAME}-kieserver"
       labels:

--- a/templates/rhdm713-trial-ephemeral.yaml
+++ b/templates/rhdm713-trial-ephemeral.yaml
@@ -1,5 +1,5 @@
 kind: Template
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 metadata:
   annotations:
     iconClass: icon-jboss


### PR DESCRIPTION
Non-groupified APIs were deprecated in OCP 4.7.

This PR only handles the imagestreams/Templates which are bundled in OpenShift. If any of the other imagestreams or templates are meant to still be used, they should also be similarly updated. A complete API list is available at https://docs.openshift.com/container-platform/4.10/rest_api/index.html .

Signed-off-by: Feny Mehta <fbm3307@gmail.com>

